### PR TITLE
Only show relative sync time when link is enabled

### DIFF
--- a/src/components/link-detail/index.js
+++ b/src/components/link-detail/index.js
@@ -199,9 +199,10 @@ export class LinkDetail extends React.Component {
           >{link.lastWebhookSync && link.lastWebhookSync.status === 'TRIGGERED' ? 'Waiting...' : 'Resync'}</Button>
         </div>
 
-        {link.lastSyncedAt ? <div className="link-detail-row link-detail-last-sync-time">
+        {link.enabled && link.lastSyncedAt ? <div className="link-detail-row link-detail-last-sync-time">
           <span>Last synced: <TimeAgo date={ link.lastSyncedAt } /></span>
         </div> : null}
+
         {/* If a syncing operation is going on, show the status info in the view */}
         {link.lastWebhookSync ? <div className="link-detail-sync-status">
           <div

--- a/src/components/link-list/styles.css
+++ b/src/components/link-list/styles.css
@@ -46,7 +46,7 @@
   border-radius: 8px;
 
   padding-top: 32px;
-  margin-top: 32px;
+  margin-top: 16px;
   margin-left: 8px;
   margin-right: 8px;
 


### PR DESCRIPTION
Doesn't make sense when a link is disabled or being created.