### PR TITLE
Fetch multiple pages of data on the dashboard

### DIFF
--- a/src/actions/collection/links/fetch.js
+++ b/src/actions/collection/links/fetch.js
@@ -7,14 +7,34 @@ export const COLLECTION_LINKS_FETCH = 'COLLECTION_LINKS_FETCH';
 export default function collectionLinksFetch() {
   return async dispatch => {
     try {
-      const resp = await fetch(`${API_URL}/v1/links`, {credentials: 'include'});
+      let currentPage = 0;
+      let aggregatedData = [];
 
-      if (resp && resp.ok) {
-        const {data, page} = await resp.json();
-        dispatch(collectionLinksSet(data, page));
-      } else if (resp) {
-        const data = await resp.text();
-        dispatch(collectionLinksError(`Error fetching links: ${data}`));
+      // Aggregate through each page of data, merging them all into one big collection.
+      while (true) {
+        const resp = await fetch(`${API_URL}/v1/links?page=${currentPage}`, {credentials: 'include'});
+
+        if (resp && resp.ok) {
+          const {data} = await resp.json();
+
+          // Add data fetched to the dataset.
+          aggregatedData = [...aggregatedData, ...data];
+
+          // Did we come across a non-full page of data? If so, we're at the end and we're done.
+          if (data.length < 20) {
+            dispatch(collectionLinksSet(aggregatedData, 0));
+            return;
+          } else {
+            // Fetched a full page of data; fetch the next page.
+            currentPage += 1;
+            continue;
+          }
+        } else if (resp) {
+          // Ran into error fetching links. We're done, return.
+          const data = await resp.text();
+          dispatch(collectionLinksError(`Error fetching links: ${data}`));
+          return;
+        }
       }
     } catch (err) {
       dispatch(collectionLinksError(`Couldn't fetch link collection: ${err.message}`));


### PR DESCRIPTION
When fetching links, fetch as many pages of data as possible, until a page comes back empty or not full. This isn't an ideal way of fetching links, but it works in the short term, Ideally, we'll want a way to page through the data on the client.