### PR TITLE
code(webhook): render the webhook for a link

### DIFF
--- a/src/components/link-detail-webhook/README.md
+++ b/src/components/link-detail-webhook/README.md
@@ -1,0 +1,7 @@
+# LinkDetailWebhook
+
+This component is shown on the link detail page and displays the given webhook url for the passed
+link.
+
+## Component Props
+- `link: BackstrokeLink` - Link to display webhook information for.

--- a/src/components/link-detail-webhook/index.js
+++ b/src/components/link-detail-webhook/index.js
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import classnames from 'classnames';
+import './styles.css';
+
+export default class LinkDetailWebhook extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = { open: false };
+  }
+  render() {
+    const {link} = this.props;
+
+    return <div className="link-detail-webhook">
+      <div
+        className={classnames('link-detail-webhook-header', {open: this.state.open})}
+        onClick={() => this.setState({open: !this.state.open})}
+      >
+        Webhook link
+        <span className="link-detail-webhook-header-arrow">&#9654;</span>
+      </div>
+      <div className={classnames('link-detail-webhook-body', {open: this.state.open})}>
+        <p>
+          Backstroke syncs your links every 10 minutes automatically. However, if you'd like to
+          sync your links more often or you'd like to sync them on demand, you can make a
+          HTTP POST request to this special url below to enqueue a manual link update.
+        </p>
+        <pre>https://api.backstroke.co/_{link.webhook}</pre>
+      </div>
+    </div>
+  }
+}

--- a/src/components/link-detail-webhook/index.js
+++ b/src/components/link-detail-webhook/index.js
@@ -23,7 +23,7 @@ export default class LinkDetailWebhook extends React.Component {
         <p>
           Backstroke syncs your links every 10 minutes automatically. However, if you'd like to
           sync your links more often or you'd like to sync them on demand, you can make a
-          HTTP POST request to this special url below to enqueue a manual link update.
+          HTTP request to this special url below to enqueue a manual link update.
         </p>
         <pre>https://api.backstroke.co/_{link.webhook}</pre>
       </div>

--- a/src/components/link-detail-webhook/styles.css
+++ b/src/components/link-detail-webhook/styles.css
@@ -1,0 +1,42 @@
+.link-detail-webhook-header {
+  height: 32px;
+  line-height: 30px;
+  display: flex;
+  user-select: none;
+
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  background-color: rgba(0, 0, 0, 0.3);
+  color: #fff;
+
+  cursor: pointer;
+}
+.link-detail-webhook-header.open {
+  background-color: #333;
+}
+.link-detail-webhook-header-arrow {
+  margin-left: auto;
+  transform: rotate(180deg);
+}
+.open .link-detail-webhook-header-arrow { transform: rotate(90deg); }
+
+.link-detail-webhook-body {
+  display: none;
+  color: #fff;
+  background-color: #444;
+  line-height: 24px;
+  font-size: 16px;
+
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+.link-detail-webhook pre {
+  font-size: 12px;
+  color: #fff;
+}
+
+.link-detail-webhook-body.open { display: block; }

--- a/src/components/link-detail/index.js
+++ b/src/components/link-detail/index.js
@@ -11,6 +11,7 @@ import TimeAgo from 'react-timeago';
 import Switch from '../toggle-switch/index';
 import LinkError from '../link-error/index';
 import Button from '../button/index';
+import LinkDetailWebhook from '../link-detail-webhook/index';
 
 import collectionLinksEnable from '../../actions/collection/links/enable';
 import collectionLinksSave from '../../actions/collection/links/save';
@@ -374,6 +375,9 @@ export class LinkDetail extends React.Component {
             </div> : null}
           </div>
         </div>
+
+        {/* Render a dropdown that shows the webhook url inside */}
+        <LinkDetailWebhook link={link} />
 
         <div className="link-detail-save-button-container">
           <Button


### PR DESCRIPTION
- Add a collapsing ui element that explains what the webhook link does
- Below the webhook description, render the link in monospace.

Here's what it looks like (collapsed and expanded):

<img width="573" alt="screen shot 2017-10-26 at 8 04 48 am" src="https://user-images.githubusercontent.com/1704236/32051946-9400283a-ba24-11e7-892d-c5474e62bae5.png">
<img width="587" alt="screen shot 2017-10-26 at 8 06 00 am" src="https://user-images.githubusercontent.com/1704236/32051948-94104cb0-ba24-11e7-8c8f-25a6edf82ed4.png">
