### PR TITLE
Extra wide cells

### DIFF
--- a/src/components/link-list/index.js
+++ b/src/components/link-list/index.js
@@ -19,6 +19,23 @@ import NoLinks from '../../images/No Links.png';
 
 const ch = new ColorHash();
 
+// When passed a link, return the width that the given link item should be on the dashboard.
+// This function is resiliant to links that may not have been completely created yet or falsey
+// values.
+function getLinkItemWidth(link) {
+  if (!link || !link.name) {
+    return null;
+  } else {
+    if (link.name.length > 32) {
+      return 3;
+    } else if (link.name.length > 16) {
+      return 2;
+    } else {
+      return 1;
+    }
+  }
+}
+
 export function LinkList({
   links,
 
@@ -49,10 +66,14 @@ export function LinkList({
         const themeColor = ch.hex(link.name);
 
         return <li
-          className={classnames(
-            'link-list-item',
-            links.loading && links.loadingSection === link.id ? 'link-list-item-loading' : null
-          )}
+          className={classnames({
+            'link-list-item': true,
+            'link-list-item-loading': links.loading && links.loadingSection === link.id,
+            // If name is 16-32 characters wide, make the cell double width.
+            'link-list-item-double-width': getLinkItemWidth(link) === 2,
+            // If name is over 32 characters wide, make the cell triple width.
+            'link-list-item-triple-width': getLinkItemWidth(link) === 3,
+          })}
           key={link.id}
           style={{backgroundColor: link.enabled ? themeColor : null}}
         >

--- a/src/components/link-list/styles.css
+++ b/src/components/link-list/styles.css
@@ -134,6 +134,8 @@
   margin-bottom: 108px;
   padding-right: 24px;
   padding-left: 24px;
+  text-overflow: ellipsis;
+  overflow-x: hidden;
 }
 .link-list-item-switch {
   display: flex;

--- a/src/components/link-list/styles.css
+++ b/src/components/link-list/styles.css
@@ -67,6 +67,16 @@
   bottom: 0px;
 }
 
+/* Long-titled cards get wider as their titles increase in width */
+.link-list-item-double-width {
+  width: 100%;
+  max-width: 558px; /* (272px * 2) + 16px padding */
+}
+.link-list-item-triple-width {
+  width: 100%;
+  max-width: 848px; /* (272px * 3) + 24px padding */
+}
+
 /* The link list loading indicator is shown when a card within the link list is in a loading state.
  * It's componsed of a :before spinner element that is visible in each card's switch. When the
  * switch is off, the spinner is light gray, and when the switch is on, the spinner is darker gray
@@ -133,11 +143,13 @@
   margin-bottom: 32px;
   position: absolute;
   bottom: 0px;
+  width: calc(100% - (2 * 24px));
 }
 .link-list-item-edit {
   margin-top: 8px;
+  margin-left: auto;
+  margin-right: 16px;
   font-size: 24px;
-  margin-left: 36px;
   color: #fff;
   font-weight: bold;
   cursor: pointer;


### PR DESCRIPTION
Previously, link items that had really long names would overflow weirdly, often out of the bounds of the cell they were in. The solution implemented here makes cells wider when they have a long name, such that they won't overflow the bounds of their container. At 12 characters, the cell will grow to be two wide, and at 32 characters, the cell will grow to be three wide.

<img width="901" alt="screen shot 2017-10-28 at 7 50 26 am" src="https://user-images.githubusercontent.com/1704236/32134150-b775ed0e-bbb4-11e7-8570-ce327641116b.png">

This still doesn't completely solve the problem, given that we're using characters and not pixel widths (1 character != a set number of pixels). However, I did some tests with `W`s (the widest character in `[A-Z]`) and while they did wrap with an ellipsis, it didn't look bad. The character sizes can always be adjusted.

I'm debating changing the center alignment on the cells to left alignment. It would look nicer with a lot of links all in one list, but not as nice when only one repo is created (the link item cell would be off-center).