### PR TITLE
Remove the `github.com`, if the user pasted a full GitHub link

### DIFF
--- a/src/components/link-detail/index.js
+++ b/src/components/link-detail/index.js
@@ -355,6 +355,10 @@ export class LinkDetail extends React.Component {
                   placeholder="username"
                   value={this.state.forkOwner}
                   onChange={e => {
+                    // Remove the `github.com`, if the user pasted a full GitHub link
+                    if (e.target.value.indexOf('github.com/') < e.target.value.length) {
+                      e.target.value = e.target.value.replace(new RegExp(".*github\\.com\\/", "mg"), "");
+                    }
                     // If a string like "abc/def" is pasted into the textbox, then properly split it
                     // into the two boxes.
                     if (e.target.value.indexOf('/') < e.target.value.length) {

--- a/src/components/link-detail/index.js
+++ b/src/components/link-detail/index.js
@@ -25,6 +25,19 @@ import RefreshIcon from '../../images/Refresh Icon.png';
 import { API_URL } from '../../constants';
 
 const ch = new ColorHash();
+const githubMatchExpression = /https?:\/\/github\.com\//;
+
+/**
+ * Remove the `github.com`, if the user pasted a full GitHub link.
+ * @param {string} url - a full GitHub link as https://github.com/backstrokeapp/dashboard
+ * @return {string} - the fixed url if the GitHub url pattern is found, otherwise the original url
+ */
+function removeGithubPrefixFromRepositoryUrl(url) {
+  if (url.search(githubMatchExpression) > -1) {
+    url = url.replace(githubMatchExpression, "");
+  }
+  return url
+}
 
 function getDefaultBranch(branchList) {
   if (branchList.indexOf('master') !== -1) {
@@ -275,11 +288,7 @@ export class LinkDetail extends React.Component {
                 placeholder="username"
                 value={this.state.upstreamOwner}
                 onChange={e => {
-                  // Remove the `github.com`, if the user pasted a full GitHub link
-                  var githubMatchExpression = new RegExp("https?:\\/\\/github\\.com\\/", "")
-                  if (e.target.value.search(githubMatchExpression) > -1) {
-                    e.target.value = e.target.value.replace(githubMatchExpression, "");
-                  }
+                  e.target.value = removeGithubPrefixFromRepositoryUrl(e.target.value);
                   // If a string like "abc/def" is pasted into the textbox, then properly split it
                   // into the two boxes.
                   if (e.target.value.indexOf('/') < e.target.value.length) {
@@ -356,11 +365,7 @@ export class LinkDetail extends React.Component {
                   placeholder="username"
                   value={this.state.forkOwner}
                   onChange={e => {
-                    // Remove the `github.com`, if the user pasted a full GitHub link
-                    var githubMatchExpression = new RegExp("https?:\\/\\/github\\.com\\/", "")
-                    if (e.target.value.search(githubMatchExpression) > -1) {
-                      e.target.value = e.target.value.replace(githubMatchExpression, "");
-                    }
+                    e.target.value = removeGithubPrefixFromRepositoryUrl(e.target.value);
                     // If a string like "abc/def" is pasted into the textbox, then properly split it
                     // into the two boxes.
                     if (e.target.value.indexOf('/') < e.target.value.length) {

--- a/src/components/link-detail/index.js
+++ b/src/components/link-detail/index.js
@@ -276,8 +276,9 @@ export class LinkDetail extends React.Component {
                 value={this.state.upstreamOwner}
                 onChange={e => {
                   // Remove the `github.com`, if the user pasted a full GitHub link
-                  if (e.target.value.indexOf('github.com/') < e.target.value.length) {
-                    e.target.value = e.target.value.replace(new RegExp(".*github\\.com\\/", "mg"), "");
+                  var githubMatchExpression = new RegExp("https?:\\/\\/github\\.com\\/", "")
+                  if (e.target.value.search(githubMatchExpression) > -1) {
+                    e.target.value = e.target.value.replace(githubMatchExpression, "");
                   }
                   // If a string like "abc/def" is pasted into the textbox, then properly split it
                   // into the two boxes.
@@ -356,8 +357,9 @@ export class LinkDetail extends React.Component {
                   value={this.state.forkOwner}
                   onChange={e => {
                     // Remove the `github.com`, if the user pasted a full GitHub link
-                    if (e.target.value.indexOf('github.com/') < e.target.value.length) {
-                      e.target.value = e.target.value.replace(new RegExp(".*github\\.com\\/", "mg"), "");
+                    var githubMatchExpression = new RegExp("https?:\\/\\/github\\.com\\/", "")
+                    if (e.target.value.search(githubMatchExpression) > -1) {
+                      e.target.value = e.target.value.replace(githubMatchExpression, "");
                     }
                     // If a string like "abc/def" is pasted into the textbox, then properly split it
                     // into the two boxes.

--- a/src/components/link-detail/index.js
+++ b/src/components/link-detail/index.js
@@ -275,6 +275,10 @@ export class LinkDetail extends React.Component {
                 placeholder="username"
                 value={this.state.upstreamOwner}
                 onChange={e => {
+                  // Remove the `github.com`, if the user pasted a full GitHub link
+                  if (e.target.value.indexOf('github.com/') < e.target.value.length) {
+                    e.target.value = e.target.value.replace(new RegExp(".*github\\.com\\/", "mg"), "");
+                  }
                   // If a string like "abc/def" is pasted into the textbox, then properly split it
                   // into the two boxes.
                   if (e.target.value.indexOf('/') < e.target.value.length) {


### PR DESCRIPTION
Inspired on the https://github.com/backstrokeapp/dashboard/pull/15 code(link-detail): when a repository like "foo/bar" is pasted into the repo box, properly separate it into the two boxes.

Some times is easier just to copy and paste the full link, as you copy it from the browser address bar, which by default (google chrome) selects all link on click.

![back2](https://user-images.githubusercontent.com/5332158/32134955-c7af3c18-bbd5-11e7-8154-f3b13206c5f9.gif)

