### PR TITLE
chore(link-list): remove vertical overflow on list items

### DIFF
--- a/src/components/link-list/styles.css
+++ b/src/components/link-list/styles.css
@@ -135,7 +135,7 @@
   padding-right: 24px;
   padding-left: 24px;
   text-overflow: ellipsis;
-  overflow-x: hidden;
+  overflow: hidden;
 }
 .link-list-item-switch {
   display: flex;


### PR DESCRIPTION
Unintentionally, the list items cell header's overflow-y was set to auto. This fixes that.