### PR TITLE
chore(link-detail): render a nicer looking loading indicator

### DIFF
--- a/src/components/link-detail/index.js
+++ b/src/components/link-detail/index.js
@@ -186,9 +186,16 @@ export class LinkDetail extends React.Component {
         props: this.props,
         state: this.state,
       });
-      return <div className="link-detail-empty">
-        No such link was found.
-      </div>;
+
+      if (this.props.loading) {
+        return <div className="link-detail-empty">
+          Loading link...
+        </div>;
+      } else {
+        return <div className="link-detail-empty">
+          No such link was found.
+        </div>;
+      }
     }
 
     return <div>

--- a/src/components/link-detail/styles.css
+++ b/src/components/link-detail/styles.css
@@ -85,6 +85,15 @@
   right: 0px;
 }
 
+/* The link detail empty state is visible when a link is loading for the first time or cannot be
+ * found. */
+.link-detail-empty {
+  text-align: center;
+  margin-top: 100px;
+  font-family: "Lato", Helvetica, Arial, sans-serif;
+  font-size: 24px;
+}
+
 /* The link detail card title--a textbox--is rendered at the top of the link detail card and used to
  * change the name of the link the detail card represents. */
 .link-detail-title {


### PR DESCRIPTION
Previously, the text was unstyled in the `.link-detail-empty`. Add some styles
to make it look (a bit) nicer.